### PR TITLE
Add TinyFish free-web grounding to L4 verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project are documented in this file.
 The format is based on Keep a Changelog.
 
+## [Unreleased]
+
+### Added
+
+- TinyFish free-web grounding for L4: when `TINYFISH_API_KEY` is set, the
+  grounded fact-check uses TinyFish Search (free, 30 req/min, structured
+  snippets) as the primary web evidence and reports the source in the verdict
+  (`tinyfish+wiki`); the keyless DuckDuckGo scrape remains the fallback
+  (`simurg/veritas/tinyfish.py`, wired in `veritas_dashboard._ground_check`)
+- hermetic tests for the TinyFish client and grounding wiring (fake Search API
+  server; no network, no key needed in CI)
+
 ## [1.0.2] - 2026-08-28
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -400,11 +400,12 @@ It stacks five layers on top of the base guard:
   guard structurally cannot have — you get it because you host the model.
 - **L3 · self-consistency** — resamples a claim and measures semantic entropy.
 - **L4 · grounded verification** — checks the claim against **real evidence**
-  (Wikipedia + web), not against the model itself. It catches BOTH a *fabricated
-  subject* (no record anywhere → abstain) AND a *wrong detail on a real subject*
-  (e.g. the answer's date contradicts the sources → abstain, and it surfaces the
-  correct date). A model cannot detect its own confident lie; external grounding
-  can.
+  (Wikipedia + the free web — TinyFish Search when `TINYFISH_API_KEY` is set,
+  keyless DuckDuckGo otherwise), not against the model itself. It catches BOTH a
+  *fabricated subject* (no record anywhere → abstain) AND a *wrong detail on a
+  real subject* (e.g. the answer's date contradicts the sources → abstain, and it
+  surfaces the correct date). A model cannot detect its own confident lie;
+  external grounding can.
 - **L5 · conformal abstention** — where the answer cannot be trusted, Monolith
   **abstains instead of asserting**.
 - **Online model** — a small logistic model over the logprob features that
@@ -450,6 +451,21 @@ mono.save("monolith_model.json")    # persist; it keeps adapting to YOUR traffic
 `fact_rows` are the per-fact-token features the guard already computes while
 streaming (entropy, margin, top-1 prob, competing alternatives). The dashboard
 does exactly this over HTTP — see `veritas_dashboard.py` (`/api/feedback`).
+
+### Free web grounding (TinyFish)
+
+The L4 web evidence prefers the [TinyFish](https://www.tinyfish.ai) Search API —
+structured results, and **free**: 30 requests/min, no card, no wallet draw:
+
+```bash
+export TINYFISH_API_KEY=...   # free key at agent.tinyfish.ai/api-keys
+python3 -m simurg.veritas_dashboard --url http://your-endpoint:PORT/v1/chat/completions --model your-model
+# the grounded verdict now reports its source: "tinyfish+wiki" instead of "web+wiki"
+```
+
+No key → the keyless DuckDuckGo scrape runs exactly as before. TinyFish is an
+opt-in evidence source: stdlib HTTP only, zero new dependencies
+(`simurg/veritas/tinyfish.py`).
 
 ### Bootstrap dataset + model
 

--- a/src/simurg/veritas/__init__.py
+++ b/src/simurg/veritas/__init__.py
@@ -24,10 +24,12 @@ from .fact_entropy import (FactUncertaintyDetector, TokenSignal, is_fact_token,
                            token_entropy, token_margin)
 from .guard import VeritasGuard
 from .semantic_entropy import semantic_entropy
+from .tinyfish import search as tinyfish_search, snippets as tinyfish_snippets
 from .verify import verify_claim
 
 __all__ = [
     "VeritasGuard", "FactUncertaintyDetector", "TokenSignal", "AbstentionGate",
     "semantic_entropy", "verify_claim", "context_grounding",
     "token_entropy", "token_margin", "is_fact_token",
+    "tinyfish_search", "tinyfish_snippets",
 ]

--- a/src/simurg/veritas/tinyfish.py
+++ b/src/simurg/veritas/tinyfish.py
@@ -1,0 +1,83 @@
+# ═══════════════════════════════════════════════════════════════════════════════
+# SIMURG · Veritas — TinyFish free-web evidence for L4 grounding
+#
+# Developed by doofZ (a.k.a Farid Aghayev from HAL-X AI)
+# Co-Founder & Head of AI at HAL-X AI.
+# Contributed by 0xsyntho.
+#
+# tinyfish — Layer-4 web evidence via the TinyFish Search API (tinyfish.ai).
+# Search is free on the free tier (30 requests/min, no card, no wallet draw),
+# so L4 grounded verification can lean on a real, structured search engine
+# instead of an unofficial HTML scrape. Stdlib only (urllib): no SDK, no new
+# dependencies — consistent with SIMURG's numpy-only promise.
+#
+# Opt-in via TINYFISH_API_KEY (free at agent.tinyfish.ai/api-keys); without a
+# key every call returns [] so callers fall back to their keyless path.
+#
+#     from simurg.veritas.tinyfish import snippets
+#     evidence = snippets("when was the Y2K bug")    # [] without a key
+#
+# Every failure mode (missing key, DNS, timeout, 4xx/5xx, rate limit, bad
+# JSON) degrades to an empty list, never an exception: grounding is a
+# best-effort evidence source, and its absence must never crash the guard.
+# ═══════════════════════════════════════════════════════════════════════════════
+from __future__ import annotations
+
+import json
+import os
+import urllib.parse
+import urllib.request
+
+DEFAULT_URL = "https://api.search.tinyfish.ai"
+_ENV_URL = "TINYFISH_SEARCH_URL"       # test / self-host override
+_ENV_KEY = "TINYFISH_API_KEY"
+_UA = "SIMURG-Veritas/1.0 (research; free-tier grounding)"
+_PURPOSE = ("Ground LLM fact-checking: find real-world evidence for this "
+            "subject and its key dates")
+
+
+def _key(api_key: str | None = None) -> str:
+    return (api_key if api_key is not None else os.environ.get(_ENV_KEY, "")) or ""
+
+
+def search(query: str, api_key: str | None = None, k: int = 6,
+           timeout: float = 12.0) -> list[dict]:
+    """Run a TinyFish web search. Returns at most ``k`` dicts of
+    ``{title, snippet, url, site_name}``. Returns [] — never raises — when no
+    key is configured, on rate limit (429), or on any transport/parse error."""
+    key = _key(api_key)
+    if not query or not key:
+        return []
+    base = os.environ.get(_ENV_URL, DEFAULT_URL)
+    params = urllib.parse.urlencode({"query": query, "purpose": _PURPOSE})
+    req = urllib.request.Request(base + "?" + params,
+                                 headers={"X-API-Key": key, "User-Agent": _UA})
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as r:
+            doc = json.loads(r.read())
+    except Exception:
+        return []
+    try:
+        out = []
+        for res in (doc.get("results") or [])[:k]:
+            title = (res.get("title") or "").strip()
+            snip = (res.get("snippet") or "").strip()
+            if title or snip:
+                out.append({"title": title, "snippet": snip,
+                            "url": res.get("url") or "",
+                            "site_name": res.get("site_name") or ""})
+        return out
+    except Exception:
+        return []
+
+
+def snippets(query: str, api_key: str | None = None, k: int = 6,
+             timeout: float = 12.0) -> list[str]:
+    """Evidence strings for L4 grounding: 'title — snippet' per result, in
+    rank order. Empty list when no key is set or the search yields nothing."""
+    out = []
+    for res in search(query, api_key=api_key, k=k, timeout=timeout):
+        line = " — ".join(x for x in (res["title"], res["snippet"]) if x)
+        if line:
+            out.append(line)
+    return out

--- a/src/simurg/veritas_dashboard.py
+++ b/src/simurg/veritas_dashboard.py
@@ -159,7 +159,8 @@ VERIFIER_MODEL = os.environ.get("VERITAS_VERIFIER_MODEL", "wahoo-1.5-preview")
 # verifier false-abstains true facts. The honest fix is EXTERNAL grounding: ask a
 # knowledge base whether the thing the user asked about actually exists. Wikipedia's
 # search hit-count discriminates cleanly: a real subject returns many articles, a
-# fabricated one returns zero.
+# fabricated one returns zero. Web evidence: TinyFish Search (free tier, 30 req/min,
+# structured) when TINYFISH_API_KEY is set — otherwise a keyless DuckDuckGo scrape.
 import urllib.parse
 
 _QWORDS = set("what when where who whom why how which is was were are am be been being "
@@ -201,8 +202,8 @@ def _wiki_hits(query: str):
         return 0, ""
 
 
-def _web_snippets(query: str, k: int = 6):
-    """Reliable web retrieval via DuckDuckGo's html endpoint (POST form)."""
+def _ddg_snippets(query: str, k: int = 6):
+    """Keyless fallback web retrieval via DuckDuckGo's html endpoint (POST form)."""
     try:
         data = urllib.parse.urlencode({"q": query, "kl": "us-en"}).encode()
         req = urlrequest.Request(
@@ -216,6 +217,22 @@ def _web_snippets(query: str, k: int = 6):
         return [re.sub(r"<[^>]+>", "", _h.unescape(s)).strip() for s in snips]
     except Exception:
         return []
+
+
+def _web_snippets(query: str, k: int = 6):
+    """L4 web evidence: TinyFish Search first (free, 30 req/min, structured —
+    needs TINYFISH_API_KEY), DuckDuckGo HTML scrape as the keyless fallback.
+    Returns (snippets, source) with source in {'tinyfish', 'ddg', 'none'}."""
+    if os.environ.get("TINYFISH_API_KEY"):
+        try:
+            from .veritas.tinyfish import snippets as _tf_snips
+            sn = _tf_snips(query, k=k)
+            if sn:
+                return sn, "tinyfish"
+        except Exception:
+            pass
+    sn = _ddg_snippets(query, k)
+    return (sn, "ddg") if sn else ([], "none")
 
 
 def _month_years(text: str):
@@ -237,13 +254,16 @@ def _ground_check(question: str, answer: str):
          subject (the hard class) ⇒ abstain, and surface the evidence's value.
     Catches BOTH the nonexistent-entity and the wrong-detail hallucination."""
     q = _subject_query(question, answer)
-    snippets = _web_snippets(question) or _web_snippets(q)
+    snippets, src = _web_snippets(question)
+    if not snippets:
+        snippets, src = _web_snippets(q)
+    web = "tinyfish" if src == "tinyfish" else "web"
     wiki_hits, wiki_title = _wiki_hits(q)
     evidence = " ".join(snippets)
     exists = len(snippets) >= 2 or wiki_hits >= 5
 
     if not snippets and wiki_hits == 0:
-        return {"decision": "abstain", "query": q, "hits": 0, "source": "web+wiki",
+        return {"decision": "abstain", "query": q, "hits": 0, "source": web + "+wiki",
                 "reason": "no knowledge-base or web record — subject appears fabricated"}
 
     a_dates = _month_years(answer)
@@ -257,20 +277,20 @@ def _ground_check(question: str, answer: str):
             return False
         if all(not agree(a, e_dates) for a in a_dates):
             ev = sorted({f"{m.title()} {y}" for m, y in e_dates})[:3]
-            return {"decision": "abstain", "query": q, "source": "web",
+            return {"decision": "abstain", "query": q, "source": web,
                     "hits": len(snippets), "top_title": wiki_title,
                     "reason": "date CONTRADICTS the evidence",
                     "claim_date": sorted({f"{m.title()} {y}" for m, y in a_dates})[:2],
                     "evidence_date": ev, "snippet": (snippets[0][:200] if snippets else "")}
-        return {"decision": "confident", "query": q, "source": "web", "hits": len(snippets),
+        return {"decision": "confident", "query": q, "source": web, "hits": len(snippets),
                 "top_title": wiki_title, "reason": "date matches the evidence"}
 
     # no comparable date claim → existence verdict
     if exists:
-        return {"decision": "confident", "query": q, "source": "web+wiki",
+        return {"decision": "confident", "query": q, "source": web + "+wiki",
                 "hits": len(snippets) or wiki_hits, "top_title": wiki_title,
                 "reason": "subject is attested by real sources"}
-    return {"decision": "hedge", "query": q, "source": "web+wiki",
+    return {"decision": "hedge", "query": q, "source": web + "+wiki",
             "hits": len(snippets) or wiki_hits, "top_title": wiki_title,
             "reason": "thin evidence — treat with caution"}
 

--- a/tests/test_tinyfish.py
+++ b/tests/test_tinyfish.py
@@ -1,0 +1,183 @@
+"""hermetic tests for TinyFish free-web grounding: a fake Search API server,
+no network access, no real key required (tests/test_tinyfish.py)."""
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+import pytest
+
+from simurg import veritas_dashboard as vd
+from simurg.veritas.tinyfish import search, snippets
+
+RESULTS = [
+    {"position": 1, "site_name": "example.com",
+     "title": "Y2K bug overview",
+     "snippet": "The Y2K bug was a class of bugs in 1999 software dating logic.",
+     "url": "https://example.com/y2k"},
+    {"position": 2, "site_name": "history.org",
+     "title": "Y2K timeline",
+     "snippet": "The Y2K bug was fixed before the year 2000 deadline.",
+     "url": "https://history.org/y2k"},
+]
+
+
+class FakeTinyFish(BaseHTTPRequestHandler):
+    results = RESULTS
+    fail = False
+    seen_keys = []
+    seen_paths = []
+
+    def log_message(self, *a):
+        pass
+
+    def do_GET(self):
+        FakeTinyFish.seen_keys.append(self.headers.get("X-API-Key"))
+        FakeTinyFish.seen_paths.append(self.path)
+        if self.fail:
+            self.send_response(500)
+            self.end_headers()
+            self.wfile.write(b"boom")
+            return
+        results = self.results
+        body = json.dumps({"query": "q", "results": results,
+                           "total_results": len(results), "page": 0}).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(body)
+
+
+@pytest.fixture()
+def tf(monkeypatch):
+    FakeTinyFish.results = RESULTS
+    FakeTinyFish.fail = False
+    FakeTinyFish.seen_keys = []
+    FakeTinyFish.seen_paths = []
+    httpd = ThreadingHTTPServer(("127.0.0.1", 0), FakeTinyFish)
+    threading.Thread(target=httpd.serve_forever, daemon=True).start()
+    monkeypatch.setenv("TINYFISH_SEARCH_URL",
+                       "http://127.0.0.1:{}".format(httpd.server_address[1]))
+    yield FakeTinyFish
+    httpd.shutdown()
+
+
+# ── client unit behaviour ──────────────────────────────────────────────────────
+
+def test_no_key_returns_empty_without_network(monkeypatch):
+    monkeypatch.delenv("TINYFISH_API_KEY", raising=False)
+    monkeypatch.setenv("TINYFISH_SEARCH_URL", "http://127.0.0.1:1")  # unroutable
+    assert search("y2k bug") == []
+    assert snippets("y2k bug") == []
+
+
+def test_search_returns_ranked_results(tf, monkeypatch):
+    monkeypatch.setenv("TINYFISH_API_KEY", "tf-test-key")
+    got = search("y2k bug", k=5)
+    assert len(got) == 2
+    assert got[0]["title"] == "Y2K bug overview"
+    assert got[0]["url"] == "https://example.com/y2k"
+    assert got[1]["site_name"] == "history.org"
+    assert FakeTinyFish.seen_keys == ["tf-test-key"]
+    assert "query=y2k+bug" in FakeTinyFish.seen_paths[0]
+
+
+def test_explicit_key_beats_environment(tf, monkeypatch):
+    monkeypatch.setenv("TINYFISH_API_KEY", "env-key")
+    got = search("y2k bug", api_key="explicit-key")
+    assert got
+    assert FakeTinyFish.seen_keys == ["explicit-key"]
+
+
+def test_snippets_merge_title_and_text(tf, monkeypatch):
+    monkeypatch.setenv("TINYFISH_API_KEY", "tf-test-key")
+    ev = snippets("y2k bug")
+    assert len(ev) == 2
+    assert ev[0].startswith("Y2K bug overview")
+    assert "1999" in ev[0]
+
+
+def test_k_limits_results(tf, monkeypatch):
+    monkeypatch.setenv("TINYFISH_API_KEY", "tf-test-key")
+    assert len(search("y2k bug", k=1)) == 1
+
+
+def test_server_error_degrades_to_empty(tf, monkeypatch):
+    monkeypatch.setenv("TINYFISH_API_KEY", "tf-test-key")
+    FakeTinyFish.fail = True
+    assert search("y2k bug") == []
+    assert snippets("y2k bug") == []
+
+
+def test_empty_result_set(tf, monkeypatch):
+    monkeypatch.setenv("TINYFISH_API_KEY", "tf-test-key")
+    FakeTinyFish.results = []
+    assert search("y2k bug") == []
+
+
+# ── grounding wiring in the veritas dashboard ──────────────────────────────────
+
+@pytest.fixture()
+def tf_env(monkeypatch, tf):
+    """TinyFish wired into _ground_check; Wikipedia stubbed for hermeticity."""
+    monkeypatch.setenv("TINYFISH_API_KEY", "tf-test-key")
+    monkeypatch.setattr(vd, "_wiki_hits", lambda q: (0, ""))
+    return tf
+
+
+def test_web_snippets_prefers_tinyfish_over_ddg(tf_env, monkeypatch):
+    monkeypatch.setattr(vd, "_ddg_snippets", lambda q, k=6: ["should-not-be-used"])
+    snips, src = vd._web_snippets("y2k bug")
+    assert src == "tinyfish"
+    assert len(snips) == 2
+    assert snips[0].startswith("Y2K bug overview")
+
+
+def test_web_snippets_keyless_falls_back_to_ddg(monkeypatch):
+    monkeypatch.delenv("TINYFISH_API_KEY", raising=False)
+    monkeypatch.setattr(vd, "_ddg_snippets", lambda q, k=6: ["ddg-snippet"])
+    snips, src = vd._web_snippets("y2k bug")
+    assert (snips, src) == (["ddg-snippet"], "ddg")
+
+
+def test_web_snippets_tinyfish_failure_falls_back_to_ddg(tf_env, monkeypatch):
+    FakeTinyFish.fail = True
+    monkeypatch.setattr(vd, "_ddg_snippets", lambda q, k=6: ["ddg-snippet"])
+    snips, src = vd._web_snippets("y2k bug")
+    assert (snips, src) == (["ddg-snippet"], "ddg")
+
+
+def test_ground_check_fabricated_subject_abstains(tf_env, monkeypatch):
+    FakeTinyFish.results = []                     # nothing on the free web
+    monkeypatch.setattr(vd, "_ddg_snippets", lambda q, k=6: [])  # no fallback evidence
+    out = vd._ground_check(
+        "When did the Zorbachian treaty of 1874 collapse?",
+        "The Zorbachian treaty collapsed in March 1874.")
+    assert out["decision"] == "abstain"
+    assert "no knowledge-base or web record" in out["reason"]
+
+
+def test_ground_check_tinyfish_date_contradiction(tf_env):
+    FakeTinyFish.results = [
+        {"position": 1, "site_name": "example.com",
+         "title": "Launch date",
+         "snippet": "The program's first public launch happened in March 2024.",
+         "url": "https://example.com/launch"},
+        {"position": 2, "site_name": "news.org",
+         "title": "Launch coverage",
+         "snippet": "Reports confirm the March 2024 launch date.",
+         "url": "https://news.org/launch"},
+    ]
+    out = vd._ground_check("When did the program first launch?",
+                           "The program first launched in July 2023.")
+    assert out["decision"] == "abstain"
+    assert out["reason"] == "date CONTRADICTS the evidence"
+    assert out["source"] == "tinyfish"
+    assert "March 2024" in out["evidence_date"]
+
+
+def test_ground_check_tinyfish_attested_subject(tf_env):
+    out = vd._ground_check("What was the Y2K bug?",
+                           "The Y2K bug was a class of software dating bugs.")
+    assert out["decision"] == "confident"
+    assert out["source"] == "tinyfish+wiki"
+    assert out["hits"] == 2


### PR DESCRIPTION
## Why

L4 grounded verification currently gets its web evidence by scraping DuckDuckGo's
unofficial HTML endpoint. It works keyless, but it can silently return nothing
(bot walls, markup changes) with no signal — and the verdict's `source` field
can't tell you which web source actually provided the evidence.

[TinyFish](https://www.tinyfish.ai) Search is a free, structured web-search API:
**30 requests/min, $0, no card, no wallet draw**. It returns exactly what L4
needs — ranked `{title, snippet, url, site_name}` results.

## What this PR adds

- **`simurg/veritas/tinyfish.py`** — a stdlib-only (urllib) client for
  `GET https://api.search.tinyfish.ai` (`X-API-Key` header, `purpose` hint).
  Every failure mode — missing key, DNS, timeout, 429, 5xx, bad JSON — degrades
  to `[]`, never an exception, so grounding can never crash the guard. Opt-in
  via `TINYFISH_API_KEY`; no new dependencies.
- **`veritas_dashboard.py`** — `_ground_check` now prefers TinyFish when a key
  is set, falls back to the keyless DuckDuckGo scrape otherwise, and reports the
  evidence source in the verdict: `tinyfish+wiki` vs `web+wiki`.
- **`tests/test_tinyfish.py`** — 11 hermetic tests against a fake Search API
  server (no network, no key needed in CI): ranked results, key handling,
  graceful degradation, and the grounding wiring (fabricated subject → abstain;
  claimed date contradicted by web evidence → abstain with the evidence's date;
  attested subject → confident).
- README (L4 bullet + a "Free web grounding (TinyFish)" section) and CHANGELOG.

## Usage

```bash
export TINYFISH_API_KEY=...   # free key: agent.tinyfish.ai/api-keys
python3 -m simurg.veritas_dashboard --url http://your-endpoint:PORT/v1/chat/completions --model your-model
```

No key → behavior is exactly as before (keyless DuckDuckGo).

## Verified live

With a real (free) key against `api.search.tinyfish.ai`:

- real subject — "What was the Y2K bug?" → `confident`, `source: tinyfish+wiki`,
  6 hits, top hit "Year 2000 problem"
- fabricated subject — "When did the Zorbachian treaty of 1874 collapse?" →
  `abstain` (web evidence contradicts the claimed date, surfaced in
  `evidence_date`)

All 25 repo tests pass (14 existing + 11 new).
