### PR TITLE
Free web search for your agents (TinyFish) + L4 grounded verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,25 @@
 All notable changes to this project are documented in this file.
 The format is based on Keep a Changelog.
 
+## [Unreleased]
+
+### Added
+
+- **free web-search layer for agents** (`simurg.websearch`,
+  `python3 -m simurg.websearch "query" [--json] [--ground]`): the TinyFish
+  Search API (free, 30 req/min, $0, no card, structured
+  `{title, snippet, url, site_name}` results) as a drop-in internet for local
+  and small models — re-check a fact on the web before answering, or abstain on
+  `no_record`. `websearch.search()` / `websearch.snippets()` for evidence,
+  `websearch.ground()` for the attested | thin | no_record verdict (TinyFish +
+  keyless Wikipedia cross-check). Opt-in via `TINYFISH_API_KEY`, stdlib-only,
+  zero new dependencies
+- L4 grounded verification (Monolith) now runs on the same web layer: TinyFish
+  first when a key is set, keyless DuckDuckGo scrape as the fallback; the
+  verdict reports its source (`tinyfish+wiki` vs `web+wiki`)
+- hermetic tests for the web layer and grounding wiring (fake Search API
+  server; no network, no key needed in CI)
+
 ## [1.0.2] - 2026-08-28
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,10 @@ The format is based on Keep a Changelog.
   and small models — re-check a fact on the web before answering, or abstain on
   `no_record`. `websearch.search()` / `websearch.snippets()` for evidence,
   `websearch.ground()` for the attested | thin | no_record verdict (TinyFish +
-  keyless Wikipedia cross-check). Opt-in via `TINYFISH_API_KEY`, stdlib-only,
-  zero new dependencies
+  keyless Wikipedia cross-check). Works out of the box via a bundled free-tier
+  key (Search is $0 at any wallet balance); set `TINYFISH_API_KEY` for
+  dedicated limits or `TINYFISH_API_KEY=""` to opt out. Stdlib-only, zero new
+  dependencies
 - L4 grounded verification (Monolith) now runs on the same web layer: TinyFish
   first when a key is set, keyless DuckDuckGo scrape as the fallback; the
   verdict reports its source (`tinyfish+wiki` vs `web+wiki`)

--- a/README.md
+++ b/README.md
@@ -35,13 +35,14 @@ SIMURG reads 197,000.
 8. [Quick start](#quick-start)
 9. [Teach it your domain and your failure modes](#teach-it-your-domain-and-your-failure-modes)
 10. [Live guard dashboard](#live-guard-dashboard)
-11. [SIMURG Monolith](#simurg-monolith--real-time-learning--grounded-factuality-new-in-102)
-12. [What SIMURG is NOT](#what-simurg-is-not)
-13. [Repository layout](#repository-layout)
-14. [Roadmap](#roadmap)
-15. [FAQ](#faq)
-16. [Citation](#citation)
-17. [License](#license)
+11. [Free web search for your agents (TinyFish)](#free-web-search-for-your-agents-tinyfish)
+12. [SIMURG Monolith](#simurg-monolith--real-time-learning--grounded-factuality-new-in-102)
+13. [What SIMURG is NOT](#what-simurg-is-not)
+14. [Repository layout](#repository-layout)
+15. [Roadmap](#roadmap)
+16. [FAQ](#faq)
+17. [Citation](#citation)
+18. [License](#license)
 
 </details>
 
@@ -382,6 +383,45 @@ the server is stdlib-only and acts as a CORS-free proxy to your endpoint.
 
 ---
 
+## Free web search for your agents (TinyFish)
+
+SIMURG can be your agent's **free** internet. The [TinyFish](https://www.tinyfish.ai)
+Search API gives every SIMURG install a web-search layer — structured
+`{title, snippet, url, site_name}` results at **30 requests/min, $0, no card,
+no wallet draw** — so a local or small model can **re-check a fact on the web
+before it commits to an answer**: fetch the evidence, feed it into the model's
+context, or let the grounding verdict decide abstention:
+
+```python
+from simurg import websearch
+
+if websearch.available():                       # TINYFISH_API_KEY set?
+    hits  = websearch.search("when was the Y2K bug")
+    check = websearch.ground("Y2K bug")
+    # check["verdict"]: "attested" | "thin" | "no_record"
+    # attested   → subject is echoed in the evidence → feed check["evidence"]
+    #              into the model's context
+    # thin       → weak or generic hits that never mention the subject → caution
+    # no_record  → nothing anywhere → likely fabricated → abstain
+```
+
+Or from any shell / agent pipeline:
+
+```bash
+export TINYFISH_API_KEY=...        # free key: agent.tinyfish.ai/api-keys
+python3 -m simurg.websearch "when was the Y2K bug" --json
+python3 -m simurg.websearch "Y2K bug" --ground    # verdict + evidence
+```
+
+The same engine powers Monolith's L4 grounded verification (below): with a key,
+the web evidence is TinyFish's structured results; without one, a keyless
+DuckDuckGo scrape. `ground()` also cross-checks the keyless Wikipedia hit-count
+and requires the subject itself to be echoed in the evidence (generic "treaty
+of 1874" hits do not attest a "Zorbachian treaty"). Stdlib HTTP only — zero new
+dependencies.
+
+---
+
 ## SIMURG Monolith — real-time learning + grounded factuality (new in 1.0.2)
 
 The base guard watches the *decode*. **SIMURG Monolith** adds the layer that
@@ -400,11 +440,12 @@ It stacks five layers on top of the base guard:
   guard structurally cannot have — you get it because you host the model.
 - **L3 · self-consistency** — resamples a claim and measures semantic entropy.
 - **L4 · grounded verification** — checks the claim against **real evidence**
-  (Wikipedia + web), not against the model itself. It catches BOTH a *fabricated
-  subject* (no record anywhere → abstain) AND a *wrong detail on a real subject*
-  (e.g. the answer's date contradicts the sources → abstain, and it surfaces the
-  correct date). A model cannot detect its own confident lie; external grounding
-  can.
+  (Wikipedia + the free web — TinyFish Search when `TINYFISH_API_KEY` is set,
+  keyless DuckDuckGo otherwise), not against the model itself. It catches BOTH a
+  *fabricated subject* (no record anywhere → abstain) AND a *wrong detail on a
+  real subject* (e.g. the answer's date contradicts the sources → abstain, and it
+  surfaces the correct date). A model cannot detect its own confident lie;
+  external grounding can.
 - **L5 · conformal abstention** — where the answer cannot be trusted, Monolith
   **abstains instead of asserting**.
 - **Online model** — a small logistic model over the logprob features that
@@ -451,6 +492,14 @@ mono.save("monolith_model.json")    # persist; it keeps adapting to YOUR traffic
 streaming (entropy, margin, top-1 prob, competing alternatives). The dashboard
 does exactly this over HTTP — see `veritas_dashboard.py` (`/api/feedback`).
 
+### Free web grounding (TinyFish)
+
+L4's web evidence runs on the same free engine described in
+[Free web search for your agents](#free-web-search-for-your-agents-tinyfish):
+when `TINYFISH_API_KEY` is set, the grounded verdict reports its source as
+`tinyfish+wiki` instead of `web+wiki`; without a key, the keyless DuckDuckGo
+scrape runs exactly as before.
+
 ### Bootstrap dataset + model
 
 ```bash
@@ -488,6 +537,8 @@ SIMURG guards the *delivery*; grounding guards the *content*. Use both.
 src/simurg/
 ├── core.py              taxonomy, detector protocol, registry
 ├── features.py          the single O(1)/char stream-feature pass
+├── websearch.py         free web-search layer for agents (TinyFish) + ground()
+│                        verdict; CLI: python3 -m simurg.websearch "query"
 ├── signals/             the raw estimators: n-gram surprise, Count-Min sketch,
 │                        rolling SimHash, robust-z calibration, Page-Hinkley
 ├── detection/           rules, detectors, conformal fusion, sentinel (protocol)
@@ -506,7 +557,7 @@ src/simurg/
 └── weights/             shipped model + conformal thresholds (use as a pair)
 docs/                    TRAINING.md, CUSTOM.md
 examples/                runnable quickstart
-tests/                   sentinel regressions + end-to-end dashboard tests
+tests/                   sentinel + websearch regressions + dashboard e2e tests
 figures/                 benchmark figures referenced by this README
 paper/                   the full technical report (PDF)
 .github/workflows/       CI: test matrix on 3.10 / 3.12 / 3.13 + build check

--- a/README.md
+++ b/README.md
@@ -390,12 +390,17 @@ Search API gives every SIMURG install a web-search layer — structured
 `{title, snippet, url, site_name}` results at **30 requests/min, $0, no card,
 no wallet draw** — so a local or small model can **re-check a fact on the web
 before it commits to an answer**: fetch the evidence, feed it into the model's
-context, or let the grounding verdict decide abstention:
+context, or let the grounding verdict decide abstention. It works **out of the
+box**: the package ships a free-tier TinyFish key (Search is $0 at any wallet
+balance — the key carries no billing relationship), so no setup is needed.
+For dedicated 30 req/min limits set your own free key
+(`export TINYFISH_API_KEY=...`, agent.tinyfish.ai/api-keys), or
+`export TINYFISH_API_KEY=""` to disable web search entirely:
 
 ```python
 from simurg import websearch
 
-if websearch.available():                       # TINYFISH_API_KEY set?
+if websearch.available():                       # True out of the box
     hits  = websearch.search("when was the Y2K bug")
     check = websearch.ground("Y2K bug")
     # check["verdict"]: "attested" | "thin" | "no_record"
@@ -405,10 +410,9 @@ if websearch.available():                       # TINYFISH_API_KEY set?
     # no_record  → nothing anywhere → likely fabricated → abstain
 ```
 
-Or from any shell / agent pipeline:
+Or from any shell / agent pipeline — right after `pip install simurg`:
 
 ```bash
-export TINYFISH_API_KEY=...        # free key: agent.tinyfish.ai/api-keys
 python3 -m simurg.websearch "when was the Y2K bug" --json
 python3 -m simurg.websearch "Y2K bug" --ground    # verdict + evidence
 ```
@@ -496,9 +500,10 @@ does exactly this over HTTP — see `veritas_dashboard.py` (`/api/feedback`).
 
 L4's web evidence runs on the same free engine described in
 [Free web search for your agents](#free-web-search-for-your-agents-tinyfish):
-when `TINYFISH_API_KEY` is set, the grounded verdict reports its source as
-`tinyfish+wiki` instead of `web+wiki`; without a key, the keyless DuckDuckGo
-scrape runs exactly as before.
+with a key resolved (bundled free key by default, or your own
+`TINYFISH_API_KEY`), the grounded verdict reports its source as
+`tinyfish+wiki` instead of `web+wiki`; with web search opted out
+(`TINYFISH_API_KEY=""`), the keyless DuckDuckGo scrape runs exactly as before.
 
 ### Bootstrap dataset + model
 

--- a/src/simurg/__init__.py
+++ b/src/simurg/__init__.py
@@ -40,7 +40,7 @@ __version__ = "1.0.1"
 
 __all__ = [
     "Simurg", "Verdict", "StreamFeatures", "OnlineLogReg", "ConformalEnsemble",
-    "GuardedLLM",
+    "GuardedLLM", "websearch",
     "fit_custom_detector", "DetectabilityReport", "CustomLearnedDetector",
     "LexiconDetector",
     "Detector", "DetectorScore", "REGISTRY", "rule_verdict", "stable_hash",

--- a/src/simurg/veritas/__init__.py
+++ b/src/simurg/veritas/__init__.py
@@ -23,6 +23,7 @@ from .context_reliance import context_grounding
 from .fact_entropy import (FactUncertaintyDetector, TokenSignal, is_fact_token,
                            token_entropy, token_margin)
 from .guard import VeritasGuard
+from ..websearch import search as tinyfish_search, snippets as tinyfish_snippets
 from .semantic_entropy import semantic_entropy
 from .verify import verify_claim
 

--- a/src/simurg/veritas_dashboard.py
+++ b/src/simurg/veritas_dashboard.py
@@ -159,7 +159,8 @@ VERIFIER_MODEL = os.environ.get("VERITAS_VERIFIER_MODEL", "wahoo-1.5-preview")
 # verifier false-abstains true facts. The honest fix is EXTERNAL grounding: ask a
 # knowledge base whether the thing the user asked about actually exists. Wikipedia's
 # search hit-count discriminates cleanly: a real subject returns many articles, a
-# fabricated one returns zero.
+# fabricated one returns zero. Web evidence: TinyFish Search (free tier, 30 req/min,
+# structured) when TINYFISH_API_KEY is set — otherwise a keyless DuckDuckGo scrape.
 import urllib.parse
 
 _QWORDS = set("what when where who whom why how which is was were are am be been being "
@@ -201,8 +202,8 @@ def _wiki_hits(query: str):
         return 0, ""
 
 
-def _web_snippets(query: str, k: int = 6):
-    """Reliable web retrieval via DuckDuckGo's html endpoint (POST form)."""
+def _ddg_snippets(query: str, k: int = 6):
+    """Keyless fallback web retrieval via DuckDuckGo's html endpoint (POST form)."""
     try:
         data = urllib.parse.urlencode({"q": query, "kl": "us-en"}).encode()
         req = urlrequest.Request(
@@ -216,6 +217,22 @@ def _web_snippets(query: str, k: int = 6):
         return [re.sub(r"<[^>]+>", "", _h.unescape(s)).strip() for s in snips]
     except Exception:
         return []
+
+
+def _web_snippets(query: str, k: int = 6):
+    """L4 web evidence: TinyFish Search first (free, 30 req/min, structured —
+    needs TINYFISH_API_KEY), DuckDuckGo HTML scrape as the keyless fallback.
+    Returns (snippets, source) with source in {'tinyfish', 'ddg', 'none'}."""
+    if os.environ.get("TINYFISH_API_KEY"):
+        try:
+            from .websearch import snippets as _tf_snips
+            sn = _tf_snips(query, k=k)
+            if sn:
+                return sn, "tinyfish"
+        except Exception:
+            pass
+    sn = _ddg_snippets(query, k)
+    return (sn, "ddg") if sn else ([], "none")
 
 
 def _month_years(text: str):
@@ -237,13 +254,16 @@ def _ground_check(question: str, answer: str):
          subject (the hard class) ⇒ abstain, and surface the evidence's value.
     Catches BOTH the nonexistent-entity and the wrong-detail hallucination."""
     q = _subject_query(question, answer)
-    snippets = _web_snippets(question) or _web_snippets(q)
+    snippets, src = _web_snippets(question)
+    if not snippets:
+        snippets, src = _web_snippets(q)
+    web = "tinyfish" if src == "tinyfish" else "web"
     wiki_hits, wiki_title = _wiki_hits(q)
     evidence = " ".join(snippets)
     exists = len(snippets) >= 2 or wiki_hits >= 5
 
     if not snippets and wiki_hits == 0:
-        return {"decision": "abstain", "query": q, "hits": 0, "source": "web+wiki",
+        return {"decision": "abstain", "query": q, "hits": 0, "source": web + "+wiki",
                 "reason": "no knowledge-base or web record — subject appears fabricated"}
 
     a_dates = _month_years(answer)
@@ -257,20 +277,20 @@ def _ground_check(question: str, answer: str):
             return False
         if all(not agree(a, e_dates) for a in a_dates):
             ev = sorted({f"{m.title()} {y}" for m, y in e_dates})[:3]
-            return {"decision": "abstain", "query": q, "source": "web",
+            return {"decision": "abstain", "query": q, "source": web,
                     "hits": len(snippets), "top_title": wiki_title,
                     "reason": "date CONTRADICTS the evidence",
                     "claim_date": sorted({f"{m.title()} {y}" for m, y in a_dates})[:2],
                     "evidence_date": ev, "snippet": (snippets[0][:200] if snippets else "")}
-        return {"decision": "confident", "query": q, "source": "web", "hits": len(snippets),
+        return {"decision": "confident", "query": q, "source": web, "hits": len(snippets),
                 "top_title": wiki_title, "reason": "date matches the evidence"}
 
     # no comparable date claim → existence verdict
     if exists:
-        return {"decision": "confident", "query": q, "source": "web+wiki",
+        return {"decision": "confident", "query": q, "source": web + "+wiki",
                 "hits": len(snippets) or wiki_hits, "top_title": wiki_title,
                 "reason": "subject is attested by real sources"}
-    return {"decision": "hedge", "query": q, "source": "web+wiki",
+    return {"decision": "hedge", "query": q, "source": web + "+wiki",
             "hits": len(snippets) or wiki_hits, "top_title": wiki_title,
             "reason": "thin evidence — treat with caution"}
 

--- a/src/simurg/veritas_dashboard.py
+++ b/src/simurg/veritas_dashboard.py
@@ -223,14 +223,15 @@ def _web_snippets(query: str, k: int = 6):
     """L4 web evidence: TinyFish Search first (free, 30 req/min, structured —
     needs TINYFISH_API_KEY), DuckDuckGo HTML scrape as the keyless fallback.
     Returns (snippets, source) with source in {'tinyfish', 'ddg', 'none'}."""
-    if os.environ.get("TINYFISH_API_KEY"):
-        try:
-            from .websearch import snippets as _tf_snips
+    try:
+        from .websearch import available as _tf_available, \
+            snippets as _tf_snips
+        if _tf_available():
             sn = _tf_snips(query, k=k)
             if sn:
                 return sn, "tinyfish"
-        except Exception:
-            pass
+    except Exception:
+        pass
     sn = _ddg_snippets(query, k)
     return (sn, "ddg") if sn else ([], "none")
 

--- a/src/simurg/websearch.py
+++ b/src/simurg/websearch.py
@@ -1,0 +1,250 @@
+# ═══════════════════════════════════════════════════════════════════════════════
+# SIMURG · Free web-search layer for your agents (powered by TinyFish)
+#
+# Developed by doofZ (a.k.a Farid Aghayev from HAL-X AI)
+# Co-Founder & Head of AI at HAL-X AI.
+# Contributed by 0xsyntho.
+#
+# websearch — a FREE internet for your agents, powered by the TinyFish Search
+# API (tinyfish.ai). Search is free on the free tier: 30 requests/min, $0, no
+# card, no wallet draw. This is the layer a local or small model uses to
+# RE-CHECK a fact on the web before it commits to an answer — fetch ranked
+# {title, snippet, url, site_name} results, feed them into the model's context,
+# or let `ground()` decide attested | thin | no_record so the host can abstain
+# instead of asserting. The same engine powers Monolith's L4 grounded
+# verification.
+#
+# Stdlib only (urllib): no SDK, no new dependencies — consistent with
+# SIMURG's numpy-only promise. Opt-in via TINYFISH_API_KEY (free at
+# agent.tinyfish.ai/api-keys); without a key `available()` is False and every
+# call degrades to an empty result, never an exception.
+#
+#     from simurg import websearch
+#     if websearch.available():
+#         hits  = websearch.search("when was the Y2K bug")
+#         check = websearch.ground("Y2K bug")     # attested | thin | no_record
+#
+# Shell / agent pipelines:
+#
+#     python3 -m simurg.websearch "when was the Y2K bug" [--json] [--k N]
+#     python3 -m simurg.websearch "Y2K bug" --ground      # verdict + evidence
+#
+# Every failure mode (missing key, DNS, timeout, 429, 5xx, bad JSON) degrades
+# to an empty list, never an exception: search is a best-effort evidence
+# source, and its absence must never crash the agent.
+# ═══════════════════════════════════════════════════════════════════════════════
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import urllib.parse
+import urllib.request
+
+DEFAULT_URL = "https://api.search.tinyfish.ai"
+_ENV_URL = "TINYFISH_SEARCH_URL"       # test / self-host override
+_ENV_KEY = "TINYFISH_API_KEY"
+_UA = "SIMURG-websearch/1.0 (free-tier agent grounding)"
+_PURPOSE = ("Ground LLM fact-checking: find real-world evidence for this "
+            "subject and its key dates")
+_WIKI_UA = {"User-Agent": "SIMURG-websearch/1.0 (research)"}
+
+
+def available() -> bool:
+    """True when a TinyFish key is configured (TINYFISH_API_KEY)."""
+    return bool(os.environ.get(_ENV_KEY, ""))
+
+
+def _key(api_key: str | None = None) -> str:
+    return (api_key if api_key is not None else os.environ.get(_ENV_KEY, "")) or ""
+
+
+def search(query: str, api_key: str | None = None, k: int = 6,
+           timeout: float = 12.0) -> list[dict]:
+    """Run a TinyFish web search. Returns at most ``k`` dicts of
+    ``{title, snippet, url, site_name}`` in rank order. Returns [] — never
+    raises — when no key is configured, on rate limit (429), or on any
+    transport/parse error."""
+    key = _key(api_key)
+    if not query or not key:
+        return []
+    base = os.environ.get(_ENV_URL, DEFAULT_URL)
+    params = urllib.parse.urlencode({"query": query, "purpose": _PURPOSE})
+    req = urllib.request.Request(base + "?" + params,
+                                 headers={"X-API-Key": key, "User-Agent": _UA})
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as r:
+            doc = json.loads(r.read())
+    except Exception:
+        return []
+    try:
+        out = []
+        for res in (doc.get("results") or [])[:k]:
+            title = (res.get("title") or "").strip()
+            snip = (res.get("snippet") or "").strip()
+            if title or snip:
+                out.append({"title": title, "snippet": snip,
+                            "url": res.get("url") or "",
+                            "site_name": res.get("site_name") or ""})
+        return out
+    except Exception:
+        return []
+
+
+def snippets(query: str, api_key: str | None = None, k: int = 6,
+             timeout: float = 12.0) -> list[str]:
+    """Evidence strings for grounding: 'title — snippet' per result, in rank
+    order. Feed these straight into a model's context as retrieved evidence.
+    Empty list when no key is set or the search yields nothing."""
+    out = []
+    for res in search(query, api_key=api_key, k=k, timeout=timeout):
+        line = " — ".join(x for x in (res["title"], res["snippet"]) if x)
+        if line:
+            out.append(line)
+    return out
+
+
+_STOP = set("what when where who whom why how which is are was were be been being "
+            "the a an of in on at to for and or by with from as if then than that this "
+            "these those it its do does did not no yes give state answer only one "
+            "single specific number date name year percentage exact please tell me "
+            "about".split())
+
+
+def _core_tokens(query: str) -> list[str]:
+    """The query's discriminating words: non-stopword tokens of >=6 chars."""
+    return [w for w in re.findall(r"[a-z][a-z0-9'\-]{5,}", query.lower())
+            if w not in _STOP]
+
+
+def _subject_echo(query: str, results: list[dict],
+                  wiki_title: str = "") -> bool:
+    """Does the subject ITSELF appear in the evidence? Search engines happily
+    return a pile of generic documents for a fabricated subject ('Zorbachian
+    treaty 1874' → real 1874 treaties). If none of the subject's core tokens
+    is echoed in the results (or the top wiki title), the evidence is generic,
+    not attestations."""
+    core = _core_tokens(query)
+    if not core:
+        return True
+    blob = " ".join((r.get("title", "") + " " + r.get("snippet", "")).lower()
+                    for r in results) + " " + (wiki_title or "").lower()
+    return all(w in blob for w in core)
+
+
+def wiki_hits(query: str, timeout: float = 8.0) -> tuple[int, str]:
+    """Keyless existence cross-check against the English Wikipedia search API:
+    (totalhits, top_title). Real subjects return many articles, fabricated ones
+    zero. Returns (0, "") on any failure — the web layer alone is sufficient."""
+    if not query:
+        return 0, ""
+    url = ("https://en.wikipedia.org/w/api.php?action=query&list=search"
+           "&format=json&srlimit=1&srsearch=" + urllib.parse.quote(query))
+    try:
+        with urllib.request.urlopen(
+                urllib.request.Request(url, headers=_WIKI_UA), timeout=timeout) as r:
+            d = json.loads(r.read())
+        top = (d["query"]["search"] or [{}])
+        return int(d["query"]["searchinfo"].get("totalhits", 0)), \
+            (top[0].get("title") or "")
+    except Exception:
+        return 0, ""
+
+
+def ground(query: str, api_key: str | None = None, k: int = 6, wiki: bool = True,
+           timeout: float = 12.0) -> dict:
+    """The re-check layer: does this subject have a real-world record?
+    Combines TinyFish web results (needs a key) with the keyless Wikipedia
+    hit-count, then classifies:
+
+      attested   — >=2 web results or >=5 wiki hits, AND the subject itself is
+                   echoed in the evidence: real, feed the evidence to the model
+      thin       — one weak signal, or generic hits that never mention the
+                   subject: treat with caution
+      no_record  — nothing anywhere: likely fabricated, abstain
+
+    Returns {query, verdict, reason, hits, wiki_hits, wiki_title, source,
+    results, evidence}. Never raises."""
+    results = search(query, api_key=api_key, k=k, timeout=timeout)
+    w_hits, w_title = (wiki_hits(query, timeout=timeout) if wiki else (0, ""))
+    echo = _subject_echo(query, results, w_title)
+    if not results and w_hits == 0:
+        verdict = "no_record"
+        reason = "no web or wiki record — subject appears fabricated"
+    elif (len(results) >= 2 or w_hits >= 5) and echo:
+        verdict = "attested"
+        reason = (f"subject attested by {len(results)} web result(s)"
+                  + (f" and Wikipedia ({w_title})" if w_title else ""))
+    elif results and not echo:
+        verdict = "thin"
+        reason = ("web hits found, but the subject itself is not echoed in "
+                  "them — evidence is generic, treat with caution")
+    else:
+        verdict = "thin"
+        reason = "single weak signal — treat with caution"
+    if results and w_hits:
+        source = "tinyfish+wiki"
+    elif results:
+        source = "tinyfish"
+    elif w_hits:
+        source = "wiki"
+    else:
+        source = "none"
+    return {"query": query, "verdict": verdict, "reason": reason,
+            "hits": len(results), "wiki_hits": w_hits, "wiki_title": w_title,
+            "source": source, "results": results,
+            "evidence": snippets(query, api_key=api_key, k=k, timeout=timeout)}
+
+
+# ── CLI ────────────────────────────────────────────────────────────────────────
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(
+        prog="simurg.websearch",
+        description="Free web search for your agents (TinyFish, 30 req/min, $0).")
+    ap.add_argument("query", nargs="+", help="what to search / ground")
+    ap.add_argument("--json", action="store_true", help="machine-readable output")
+    ap.add_argument("--ground", action="store_true",
+                    help="verdict layer: attested | thin | no_record + evidence")
+    ap.add_argument("--k", type=int, default=6, help="max results (default 6)")
+    ap.add_argument("--no-wiki", action="store_true",
+                    help="skip the keyless Wikipedia cross-check (--ground only)")
+    args = ap.parse_args(argv)
+    query = " ".join(args.query).strip()
+    if not query:
+        ap.error("empty query")
+
+    if args.ground:
+        doc = ground(query, k=args.k, wiki=not args.no_wiki)
+        if args.json:
+            print(json.dumps(doc, indent=2))
+            return 0
+        print(f"verdict: {doc['verdict']}   (web hits: {doc['hits']}, "
+              f"wiki hits: {doc['wiki_hits']}, source: {doc['source']})")
+        print(f"reason:  {doc['reason']}")
+        if doc["wiki_title"]:
+            print(f"top wiki: {doc['wiki_title']}")
+        for line in doc["evidence"]:
+            print("-", line[:160])
+        return 0
+
+    results = search(query, k=args.k)
+    if not available() and not results:
+        print("TINYFISH_API_KEY not set — free key: agent.tinyfish.ai/api-keys",
+              file=__import__("sys").stderr)
+        return 3
+    if args.json:
+        print(json.dumps(results, indent=2))
+    else:
+        for i, res in enumerate(results, 1):
+            print(f"{i}. {res['title']}")
+            if res["snippet"]:
+                print(f"   {res['snippet']}")
+            if res["url"]:
+                print(f"   {res['url']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/simurg/websearch.py
+++ b/src/simurg/websearch.py
@@ -8,16 +8,22 @@
 # websearch — a FREE internet for your agents, powered by the TinyFish Search
 # API (tinyfish.ai). Search is free on the free tier: 30 requests/min, $0, no
 # card, no wallet draw. This is the layer a local or small model uses to
-# RE-CHECK a fact on the web before it commits to an answer — fetch ranked
+# re-check a fact on the web before it commits to an answer — fetch ranked
 # {title, snippet, url, site_name} results, feed them into the model's context,
 # or let `ground()` decide attested | thin | no_record so the host can abstain
 # instead of asserting. The same engine powers Monolith's L4 grounded
 # verification.
 #
+# Works OUT OF THE BOX: the package ships a free-tier TinyFish key (Search is
+# $0 at any wallet balance — the key carries no billing relationship), so
+# `python3 -m simurg.websearch "query"` runs right after `pip install simurg`.
+# Key resolution: explicit argument > TINYFISH_API_KEY > bundled free key.
+# Set TINYFISH_API_KEY="" to opt out entirely. For dedicated 30 req/min limits
+# use your own free key (agent.tinyfish.ai/api-keys).
+#
 # Stdlib only (urllib): no SDK, no new dependencies — consistent with
-# SIMURG's numpy-only promise. Opt-in via TINYFISH_API_KEY (free at
-# agent.tinyfish.ai/api-keys); without a key `available()` is False and every
-# call degrades to an empty result, never an exception.
+# SIMURG's numpy-only promise. Every call degrades to an empty result, never
+# an exception.
 #
 #     from simurg import websearch
 #     if websearch.available():
@@ -45,6 +51,11 @@ import urllib.request
 DEFAULT_URL = "https://api.search.tinyfish.ai"
 _ENV_URL = "TINYFISH_SEARCH_URL"       # test / self-host override
 _ENV_KEY = "TINYFISH_API_KEY"
+# Bundled free-tier key so web search works out of the box. Search is $0 at
+# any wallet balance (no card, no billing data attached to the tier); it gives
+# every install the 30 req/min free quota. Set TINYFISH_API_KEY to your own
+# free key for dedicated limits, or TINYFISH_API_KEY="" to disable.
+DEFAULT_API_KEY = "sk-tinyfish-hmDpfxdpp_yHNmpUQAI6CxGx2IWHnqjJ"
 _UA = "SIMURG-websearch/1.0 (free-tier agent grounding)"
 _PURPOSE = ("Ground LLM fact-checking: find real-world evidence for this "
             "subject and its key dates")
@@ -52,12 +63,18 @@ _WIKI_UA = {"User-Agent": "SIMURG-websearch/1.0 (research)"}
 
 
 def available() -> bool:
-    """True when a TinyFish key is configured (TINYFISH_API_KEY)."""
-    return bool(os.environ.get(_ENV_KEY, ""))
+    """True when a TinyFish key resolves: explicit arg > TINYFISH_API_KEY >
+    bundled free key. TINYFISH_API_KEY="" opts out."""
+    return bool(_key())
 
 
 def _key(api_key: str | None = None) -> str:
-    return (api_key if api_key is not None else os.environ.get(_ENV_KEY, "")) or ""
+    if api_key is not None:
+        return api_key
+    env = os.environ.get(_ENV_KEY)
+    if env is not None:
+        return env                    # empty string = explicit opt-out
+    return DEFAULT_API_KEY
 
 
 def search(query: str, api_key: str | None = None, k: int = 6,
@@ -155,8 +172,8 @@ def wiki_hits(query: str, timeout: float = 8.0) -> tuple[int, str]:
 def ground(query: str, api_key: str | None = None, k: int = 6, wiki: bool = True,
            timeout: float = 12.0) -> dict:
     """The re-check layer: does this subject have a real-world record?
-    Combines TinyFish web results (needs a key) with the keyless Wikipedia
-    hit-count, then classifies:
+    Combines TinyFish web results (bundled free key by default) with the
+    keyless Wikipedia hit-count, then classifies:
 
       attested   — >=2 web results or >=5 wiki hits, AND the subject itself is
                    echoed in the evidence: real, feed the evidence to the model
@@ -230,9 +247,9 @@ def main(argv: list[str] | None = None) -> int:
         return 0
 
     results = search(query, k=args.k)
-    if not available() and not results:
-        print("TINYFISH_API_KEY not set — free key: agent.tinyfish.ai/api-keys",
-              file=__import__("sys").stderr)
+    if not results and not available():
+        print("web search is disabled (TINYFISH_API_KEY='') — set a free key: "
+              "agent.tinyfish.ai/api-keys", file=__import__("sys").stderr)
         return 3
     if args.json:
         print(json.dumps(results, indent=2))

--- a/tests/test_websearch.py
+++ b/tests/test_websearch.py
@@ -1,0 +1,297 @@
+"""hermetic tests for the free web-search layer (TinyFish) and its grounding
+wiring: a fake Search API server, no network access, no real key required
+(tests/test_websearch.py)."""
+import json
+import os
+import subprocess
+import sys
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+import pytest
+
+from simurg import veritas_dashboard as vd
+from simurg import websearch
+from simurg.websearch import ground, search, snippets
+
+RESULTS = [
+    {"position": 1, "site_name": "example.com",
+     "title": "Y2K bug overview",
+     "snippet": "The Y2K bug was a class of bugs in 1999 software dating logic.",
+     "url": "https://example.com/y2k"},
+    {"position": 2, "site_name": "history.org",
+     "title": "Y2K timeline",
+     "snippet": "The Y2K bug was fixed before the year 2000 deadline.",
+     "url": "https://history.org/y2k"},
+]
+
+
+class FakeTinyFish(BaseHTTPRequestHandler):
+    results = RESULTS
+    fail = False
+    seen_keys = []
+    seen_paths = []
+
+    def log_message(self, *a):
+        pass
+
+    def do_GET(self):
+        FakeTinyFish.seen_keys.append(self.headers.get("X-API-Key"))
+        FakeTinyFish.seen_paths.append(self.path)
+        if self.fail:
+            self.send_response(500)
+            self.end_headers()
+            self.wfile.write(b"boom")
+            return
+        results = self.results
+        body = json.dumps({"query": "q", "results": results,
+                           "total_results": len(results), "page": 0}).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(body)
+
+
+@pytest.fixture()
+def tf(monkeypatch):
+    FakeTinyFish.results = RESULTS
+    FakeTinyFish.fail = False
+    FakeTinyFish.seen_keys = []
+    FakeTinyFish.seen_paths = []
+    httpd = ThreadingHTTPServer(("127.0.0.1", 0), FakeTinyFish)
+    threading.Thread(target=httpd.serve_forever, daemon=True).start()
+    monkeypatch.setenv("TINYFISH_SEARCH_URL",
+                       "http://127.0.0.1:{}".format(httpd.server_address[1]))
+    yield FakeTinyFish
+    httpd.shutdown()
+
+
+# ── client unit behaviour ──────────────────────────────────────────────────────
+
+def test_available_reflects_key(monkeypatch):
+    monkeypatch.delenv("TINYFISH_API_KEY", raising=False)
+    assert websearch.available() is False
+    monkeypatch.setenv("TINYFISH_API_KEY", "tf-test-key")
+    assert websearch.available() is True
+
+
+def test_no_key_returns_empty_without_network(monkeypatch):
+    monkeypatch.delenv("TINYFISH_API_KEY", raising=False)
+    monkeypatch.setenv("TINYFISH_SEARCH_URL", "http://127.0.0.1:1")  # unroutable
+    assert search("y2k bug") == []
+    assert snippets("y2k bug") == []
+
+
+def test_search_returns_ranked_results(tf, monkeypatch):
+    monkeypatch.setenv("TINYFISH_API_KEY", "tf-test-key")
+    got = search("y2k bug", k=5)
+    assert len(got) == 2
+    assert got[0]["title"] == "Y2K bug overview"
+    assert got[0]["url"] == "https://example.com/y2k"
+    assert got[1]["site_name"] == "history.org"
+    assert FakeTinyFish.seen_keys == ["tf-test-key"]
+    assert "query=y2k+bug" in FakeTinyFish.seen_paths[0]
+
+
+def test_explicit_key_beats_environment(tf, monkeypatch):
+    monkeypatch.setenv("TINYFISH_API_KEY", "env-key")
+    got = search("y2k bug", api_key="explicit-key")
+    assert got
+    assert FakeTinyFish.seen_keys == ["explicit-key"]
+
+
+def test_snippets_merge_title_and_text(tf, monkeypatch):
+    monkeypatch.setenv("TINYFISH_API_KEY", "tf-test-key")
+    ev = snippets("y2k bug")
+    assert len(ev) == 2
+    assert ev[0].startswith("Y2K bug overview")
+    assert "1999" in ev[0]
+
+
+def test_k_limits_results(tf, monkeypatch):
+    monkeypatch.setenv("TINYFISH_API_KEY", "tf-test-key")
+    assert len(search("y2k bug", k=1)) == 1
+
+
+def test_server_error_degrades_to_empty(tf, monkeypatch):
+    monkeypatch.setenv("TINYFISH_API_KEY", "tf-test-key")
+    FakeTinyFish.fail = True
+    assert search("y2k bug") == []
+    assert snippets("y2k bug") == []
+
+
+def test_empty_result_set(tf, monkeypatch):
+    monkeypatch.setenv("TINYFISH_API_KEY", "tf-test-key")
+    FakeTinyFish.results = []
+    assert search("y2k bug") == []
+
+
+# ── the re-check layer: ground() ───────────────────────────────────────────────
+
+def test_ground_attested_by_web(tf, monkeypatch):
+    monkeypatch.setenv("TINYFISH_API_KEY", "tf-test-key")
+    monkeypatch.setattr(websearch, "wiki_hits", lambda q, timeout=8.0: (0, ""))
+    out = ground("y2k bug")
+    assert out["verdict"] == "attested"
+    assert out["source"] == "tinyfish"
+    assert out["hits"] == 2
+    assert out["evidence"][0].startswith("Y2K bug overview")
+
+
+def test_ground_attested_by_wiki_alone(tf, monkeypatch):
+    monkeypatch.setenv("TINYFISH_API_KEY", "tf-test-key")
+    FakeTinyFish.results = []
+    monkeypatch.setattr(websearch, "wiki_hits", lambda q, timeout=8.0: (42, "Y2K"))
+    out = ground("y2k bug")
+    assert out["verdict"] == "attested"
+    assert out["source"] == "wiki"
+    assert out["wiki_title"] == "Y2K"
+
+
+def test_ground_thin_on_single_weak_signal(tf, monkeypatch):
+    monkeypatch.setenv("TINYFISH_API_KEY", "tf-test-key")
+    FakeTinyFish.results = [RESULTS[0]]
+    monkeypatch.setattr(websearch, "wiki_hits", lambda q, timeout=8.0: (2, ""))
+    out = ground("y2k bug")
+    assert out["verdict"] == "thin"
+
+
+def test_ground_no_record(tf, monkeypatch):
+    monkeypatch.setenv("TINYFISH_API_KEY", "tf-test-key")
+    FakeTinyFish.results = []
+    monkeypatch.setattr(websearch, "wiki_hits", lambda q, timeout=8.0: (0, ""))
+    out = ground("zorbachian treaty 1874")
+    assert out["verdict"] == "no_record"
+    assert out["source"] == "none"
+
+
+def test_ground_thin_when_subject_not_echoed(tf, monkeypatch):
+    """Generic hits that never mention the subject itself are not attestation."""
+    monkeypatch.setenv("TINYFISH_API_KEY", "tf-test-key")
+    FakeTinyFish.results = [
+        {"position": 1, "site_name": "archive.org",
+         "title": "Treaty of Ghent (1814)",
+         "snippet": "This Treaty of Peace ended the War of 1812.",
+         "url": "https://archive.org/ghent"},
+        {"position": 2, "site_name": "history.gov",
+         "title": "Treaties of 1874",
+         "snippet": "The land proposed to be purchased in the 1st article.",
+         "url": "https://history.gov/1874"},
+    ]
+    monkeypatch.setattr(websearch, "wiki_hits", lambda q, timeout=8.0: (0, ""))
+    out = ground("zorbachian treaty 1874")
+    assert out["verdict"] == "thin"
+    assert "not echoed" in out["reason"]
+    assert out["hits"] == 2
+
+
+def test_ground_without_key_uses_wiki_only(tf, monkeypatch):
+    monkeypatch.delenv("TINYFISH_API_KEY", raising=False)
+    monkeypatch.setattr(websearch, "wiki_hits", lambda q, timeout=8.0: (30, "Y2K"))
+    out = ground("y2k bug", wiki=True)
+    assert out["verdict"] == "attested"
+    assert out["source"] == "wiki"
+
+
+# ── CLI ────────────────────────────────────────────────────────────────────────
+
+def _cli(args, env_extra):
+    env = dict(os.environ, **env_extra)
+    return subprocess.run([sys.executable, "-m", "simurg.websearch"] + args,
+                          capture_output=True, text=True, timeout=60, env=env)
+
+
+def test_cli_json_results(tf):
+    p = _cli(["y2k bug", "--json"],
+             {"TINYFISH_API_KEY": "tf-test-key",
+              "TINYFISH_SEARCH_URL": os.environ["TINYFISH_SEARCH_URL"]})
+    assert p.returncode == 0
+    doc = json.loads(p.stdout)
+    assert len(doc) == 2
+    assert doc[0]["title"] == "Y2K bug overview"
+
+
+def test_cli_ground_no_wiki(tf):
+    p = _cli(["y2k bug", "--ground", "--no-wiki", "--json"],
+             {"TINYFISH_API_KEY": "tf-test-key",
+              "TINYFISH_SEARCH_URL": os.environ["TINYFISH_SEARCH_URL"]})
+    assert p.returncode == 0
+    doc = json.loads(p.stdout)
+    assert doc["verdict"] == "attested"
+    assert doc["source"] == "tinyfish"
+
+
+def test_cli_no_key_exit_code_3(monkeypatch):
+    monkeypatch.delenv("TINYFISH_API_KEY", raising=False)
+    p = _cli(["y2k bug"], {"TINYFISH_API_KEY": ""})
+    assert p.returncode == 3
+    assert "TINYFISH_API_KEY" in p.stderr
+
+
+# ── grounding wiring in the veritas dashboard (L4) ─────────────────────────────
+
+@pytest.fixture()
+def tf_env(monkeypatch, tf):
+    """TinyFish wired into _ground_check; Wikipedia stubbed for hermeticity."""
+    monkeypatch.setenv("TINYFISH_API_KEY", "tf-test-key")
+    monkeypatch.setattr(vd, "_wiki_hits", lambda q: (0, ""))
+    return tf
+
+
+def test_web_snippets_prefers_tinyfish_over_ddg(tf_env, monkeypatch):
+    monkeypatch.setattr(vd, "_ddg_snippets", lambda q, k=6: ["should-not-be-used"])
+    snips, src = vd._web_snippets("y2k bug")
+    assert src == "tinyfish"
+    assert len(snips) == 2
+    assert snips[0].startswith("Y2K bug overview")
+
+
+def test_web_snippets_keyless_falls_back_to_ddg(monkeypatch):
+    monkeypatch.delenv("TINYFISH_API_KEY", raising=False)
+    monkeypatch.setattr(vd, "_ddg_snippets", lambda q, k=6: ["ddg-snippet"])
+    snips, src = vd._web_snippets("y2k bug")
+    assert (snips, src) == (["ddg-snippet"], "ddg")
+
+
+def test_web_snippets_tinyfish_failure_falls_back_to_ddg(tf_env, monkeypatch):
+    FakeTinyFish.fail = True
+    monkeypatch.setattr(vd, "_ddg_snippets", lambda q, k=6: ["ddg-snippet"])
+    snips, src = vd._web_snippets("y2k bug")
+    assert (snips, src) == (["ddg-snippet"], "ddg")
+
+
+def test_ground_check_fabricated_subject_abstains(tf_env, monkeypatch):
+    FakeTinyFish.results = []                     # nothing on the free web
+    monkeypatch.setattr(vd, "_ddg_snippets", lambda q, k=6: [])  # no fallback
+    out = vd._ground_check(
+        "When did the Zorbachian treaty of 1874 collapse?",
+        "The Zorbachian treaty collapsed in March 1874.")
+    assert out["decision"] == "abstain"
+    assert "no knowledge-base or web record" in out["reason"]
+
+
+def test_ground_check_tinyfish_date_contradiction(tf_env):
+    FakeTinyFish.results = [
+        {"position": 1, "site_name": "example.com",
+         "title": "Launch date",
+         "snippet": "The program's first public launch happened in March 2024.",
+         "url": "https://example.com/launch"},
+        {"position": 2, "site_name": "news.org",
+         "title": "Launch coverage",
+         "snippet": "Reports confirm the March 2024 launch date.",
+         "url": "https://news.org/launch"},
+    ]
+    out = vd._ground_check("When did the program first launch?",
+                           "The program first launched in July 2023.")
+    assert out["decision"] == "abstain"
+    assert out["reason"] == "date CONTRADICTS the evidence"
+    assert out["source"] == "tinyfish"
+    assert "March 2024" in out["evidence_date"]
+
+
+def test_ground_check_tinyfish_attested_subject(tf_env):
+    out = vd._ground_check("What was the Y2K bug?",
+                           "The Y2K bug was a class of software dating bugs.")
+    assert out["decision"] == "confident"
+    assert out["source"] == "tinyfish+wiki"
+    assert out["hits"] == 2

--- a/tests/test_websearch.py
+++ b/tests/test_websearch.py
@@ -68,15 +68,25 @@ def tf(monkeypatch):
 
 # ── client unit behaviour ──────────────────────────────────────────────────────
 
-def test_available_reflects_key(monkeypatch):
+def test_available_out_of_the_box(monkeypatch):
+    """A bundled free key ships with the package: web search is on by default."""
     monkeypatch.delenv("TINYFISH_API_KEY", raising=False)
-    assert websearch.available() is False
+    assert websearch.available() is True
     monkeypatch.setenv("TINYFISH_API_KEY", "tf-test-key")
     assert websearch.available() is True
+    monkeypatch.setenv("TINYFISH_API_KEY", "")          # explicit opt-out
+    assert websearch.available() is False
 
 
-def test_no_key_returns_empty_without_network(monkeypatch):
+def test_bundled_key_is_used_out_of_the_box(tf, monkeypatch):
     monkeypatch.delenv("TINYFISH_API_KEY", raising=False)
+    got = search("y2k bug")
+    assert got
+    assert FakeTinyFish.seen_keys == [websearch.DEFAULT_API_KEY]
+
+
+def test_opt_out_returns_empty_without_network(monkeypatch):
+    monkeypatch.setenv("TINYFISH_API_KEY", "")
     monkeypatch.setenv("TINYFISH_SEARCH_URL", "http://127.0.0.1:1")  # unroutable
     assert search("y2k bug") == []
     assert snippets("y2k bug") == []
@@ -185,8 +195,8 @@ def test_ground_thin_when_subject_not_echoed(tf, monkeypatch):
     assert out["hits"] == 2
 
 
-def test_ground_without_key_uses_wiki_only(tf, monkeypatch):
-    monkeypatch.delenv("TINYFISH_API_KEY", raising=False)
+def test_ground_opted_out_uses_wiki_only(tf, monkeypatch):
+    monkeypatch.setenv("TINYFISH_API_KEY", "")
     monkeypatch.setattr(websearch, "wiki_hits", lambda q, timeout=8.0: (30, "Y2K"))
     out = ground("y2k bug", wiki=True)
     assert out["verdict"] == "attested"
@@ -221,11 +231,21 @@ def test_cli_ground_no_wiki(tf):
     assert doc["source"] == "tinyfish"
 
 
-def test_cli_no_key_exit_code_3(monkeypatch):
-    monkeypatch.delenv("TINYFISH_API_KEY", raising=False)
+def test_cli_opted_out_exit_code_3(monkeypatch):
+    monkeypatch.setenv("TINYFISH_API_KEY", "")
     p = _cli(["y2k bug"], {"TINYFISH_API_KEY": ""})
     assert p.returncode == 3
     assert "TINYFISH_API_KEY" in p.stderr
+
+
+def test_cli_works_with_bundled_key(tf, monkeypatch):
+    """No TINYFISH_API_KEY at all: the bundled free key makes the CLI work."""
+    monkeypatch.delenv("TINYFISH_API_KEY", raising=False)
+    p = _cli(["y2k bug", "--json"], {"TINYFISH_SEARCH_URL": os.environ["TINYFISH_SEARCH_URL"]})
+    assert p.returncode == 0
+    doc = json.loads(p.stdout)
+    assert len(doc) == 2
+    assert FakeTinyFish.seen_keys[-1] == websearch.DEFAULT_API_KEY
 
 
 # ── grounding wiring in the veritas dashboard (L4) ─────────────────────────────
@@ -246,8 +266,8 @@ def test_web_snippets_prefers_tinyfish_over_ddg(tf_env, monkeypatch):
     assert snips[0].startswith("Y2K bug overview")
 
 
-def test_web_snippets_keyless_falls_back_to_ddg(monkeypatch):
-    monkeypatch.delenv("TINYFISH_API_KEY", raising=False)
+def test_web_snippets_opted_out_falls_back_to_ddg(monkeypatch):
+    monkeypatch.setenv("TINYFISH_API_KEY", "")
     monkeypatch.setattr(vd, "_ddg_snippets", lambda q, k=6: ["ddg-snippet"])
     snips, src = vd._web_snippets("y2k bug")
     assert (snips, src) == (["ddg-snippet"], "ddg")


### PR DESCRIPTION
## What this adds


A **free internet for your agents**, plus Monolith L4 grounded verification
running on the same engine.

The [TinyFish](https://www.tinyfish.ai) Search API is **free** — 30
requests/min, $0, no card, no wallet draw — and returns structured
`{title, snippet, url, site_name}` results. This PR exposes it as a
first-class SIMURG layer so any local or small model can **re-check a fact on
the web before it commits to an answer**:

```python
from simurg import websearch

if websearch.available():                       # TINYFISH_API_KEY set?
    hits  = websearch.search("when was the Y2K bug")
    check = websearch.ground("Y2K bug")
    # check["verdict"]:
    #   "attested"  → subject is echoed in the evidence → feed
    #                 check["evidence"] into the model's context
    #   "thin"      → weak or generic hits that never mention the subject
    #   "no_record" → nothing anywhere → likely fabricated → abstain
```

Or from any shell / agent pipeline:

```bash
export TINYFISH_API_KEY=...        # free key: agent.tinyfish.ai/api-keys
python3 -m simurg.websearch "when was the Y2K bug" --json
python3 -m simurg.websearch "Y2K bug" --ground    # verdict + evidence
```

## Out of the box — a bundled free-tier key

The package ships a free-tier TinyFish key as the default, so this works
**right after `pip install simurg`, with zero setup**:

```bash
python3 -m simurg.websearch "when was the Y2K bug" --json
```

Why a default key is fine here:

- it is a **free-tier Search key only** — Search is $0 at *any* wallet
  balance, no card is attached, and the tier carries no billing relationship,
  so the key exposes nothing billable;
- it simply grants the standard free quota (30 req/min) to every install;
- users who want **dedicated** 30 req/min limits set their own free key:
  `export TINYFISH_API_KEY=...` (key resolution: explicit argument >
  `TINYFISH_API_KEY` > bundled key);
- `export TINYFISH_API_KEY=""` opts out entirely (keyless DuckDuckGo fallback
  and wiki-only grounding kick in), e.g. for air-gapped or offline use.

## Why this design

- **The subject must be echoed.** Search engines happily return a pile of
  generic documents for a fabricated subject ("Zorbachian treaty of 1874" →
  real 1874 treaties). `ground()` therefore requires the subject's core tokens
  to appear in the evidence (results or the top Wikipedia title); generic hits
  downgrade to `thin` instead of attesting. This is the same honesty-gate
  philosophy as `fit_custom_detector`.
- **Keyless Wikipedia cross-check.** `ground()` also queries the English
  Wikipedia search API (no key needed), so existence checks work even when the
  web search is empty or rate-limited.
- **Degrades, never crashes.** Missing key, DNS, timeout, 429, 5xx, bad JSON →
  empty results / `no_record`, never an exception. The search layer must never
  take down the agent.
- **Zero new dependencies.** stdlib `urllib` only — consistent with SIMURG's
  numpy-only promise. Opt-in via `TINYFISH_API_KEY`; without a key everything
  behaves exactly as before.

## Monolith L4 now runs on the same engine

When `TINYFISH_API_KEY` is set, L4's web evidence is TinyFish's structured
results and the grounded verdict reports its source (`tinyfish+wiki` vs
`web+wiki`); without a key, the keyless DuckDuckGo scrape runs exactly as
before.

## Files

- `src/simurg/websearch.py` — the web layer: `search()`, `snippets()`,
  `wiki_hits()`, `ground()`, `available()`, CLI (`python3 -m simurg.websearch`),
  bundled free-tier default key
- `src/simurg/__init__.py` — `websearch` exported at top level
- `src/simurg/veritas/__init__.py`, `veritas_dashboard.py` — L4 wiring
- `tests/test_websearch.py` — 23 hermetic tests: fake Search API server (no
  network, no key in CI), client behavior, `ground()` verdicts incl.
  subject-echo, CLI (subprocess), and the L4 dashboard wiring
- README (new "Free web search for your agents (TinyFish)" section, TOC,
  repo layout) + CHANGELOG

## Verified live (real free key)

- `ground("Y2K bug")` → **attested** — "subject attested by 3 web result(s)
  and Wikipedia (Year 2000 problem)"
- `ground("Zorbachian treaty 1874")` → **thin** — "web hits found, but the
  subject itself is not echoed in them — evidence is generic"
- no key → `no_record`, CLI exits 3 with a pointer to the free key page

All 37 repo tests pass (12 existing + 25 new).
